### PR TITLE
Fix render call syntax in main.jsx

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,5 +6,5 @@ import './index.css'
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-)
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- remove trailing comma from StrictMode wrapper
- properly terminate render call with semicolon

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Transform failed with 1 error: Expected "{" but found "\\" in App.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b7193968588325b8aff15d458bc363